### PR TITLE
Migration created

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hogwartslegacy",
-  "version": "0.2.0",
+  "version": "0.2.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hogwartslegacy",
-      "version": "0.2.0",
+      "version": "0.2.11",
       "license": "GPLV3",
       "devDependencies": {
         "@types/node": "^18.11.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hogwartslegacy",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Vortex Extension for Hogwarts Legacy",
   "author": "lordvoldem0rt",
   "private": true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,7 @@ function main(context: types.IExtensionContext) {
 
   context.registerModType(
     "hogwarts-PAK-modtype",
-    30,
+    25,
     (gameId) => gameId === GAME_ID,
     (game) => GetPakModsPath(context, game),
     (instructions) => TestForPakModType(instructions),
@@ -191,7 +191,7 @@ function GetPakModsPath(context: IExtensionContext, game: IGame): string {
   else return undefined;
 }
 
-function TestForPakModType(insturctions: IInstruction[]): boolean {
+async function TestForPakModType(insturctions: IInstruction[]): Promise<boolean> {
   const copyInstructions = insturctions.filter(i => i.type === 'copy');
   const pakInstallInstructions = copyInstructions.filter(i => path.extname(i.source) === '.pak');
   if (!pakInstallInstructions.length) return false;
@@ -203,7 +203,8 @@ function TestForPakModType(insturctions: IInstruction[]): boolean {
     i.source.toLowerCase().endsWith('.ue4sslogicmod') ||
     i.source.toLowerCase().endsWith('.logicmod')
   );
-  return !!excludeInstructions ? false : true
+  // console.log('Pak mod?', !!excludeInstructions ? false : true);
+  return !!excludeInstructions ? false : true;
 }
 
 function TestMerge(context: IExtensionContext, game: IGame, gameDiscovery: IDiscoveryResult): IMergeFilter {
@@ -577,7 +578,7 @@ async function DeserializeLoadOrder(context: types.IExtensionContext): Promise<t
   const filteredData = data.filter((entry) => enabledModIds.includes(entry.id));
 
   // Check if the user added any new mods, and only add things that aren't in collections and aren't movies types
-  const newMods = enabledModIds.filter((id) => mods[id]?.type != "collection" && filteredData.find((loEntry) => loEntry.id === id) === undefined);
+  const newMods = enabledModIds.filter((id) => mods[id]?.type === "hogwarts-PAK-modtype" && filteredData.find((loEntry) => loEntry.id === id) === undefined);
 
   // removed mods[id]?.type != "hogwarts-modtype-movies"
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ function main(context: types.IExtensionContext) {
   context.registerGame({
     id: GAME_ID,
     name: "Hogwarts Legacy",
-    mergeMods: false,
+    mergeMods: true,
     getGameVersion: getGameVersion,
     queryPath: findGame,
     supportedTools: [],

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -1,0 +1,42 @@
+import path from 'path';
+import { types, log, actions } from 'vortex-api';
+
+const GAME_ID = "hogwartslegacy";
+const MODSFOLDER_PATH = path.join("Phoenix", "Content", "Paks", "~mods");
+
+
+export async function migrate0_2_11(context: types.IExtensionContext, oldversion: string) {
+    log('info', 'Migrating to 0.2.11');
+
+    const state = context.api.getState();
+    const mods = state.persistent.mods[GAME_ID] ?? {};
+
+    if (!!Object.keys(mods)) {
+        log('info', 'No mods to migrate for Hogwarts Legacy');
+        return;
+    }
+
+    // Find mods that have PAKs and change the modtype.
+    const defaultMods = Object.values(mods).filter(m => m.type === '');
+    if (!defaultMods.length) return;
+
+    // Clean up the ~mods folder.
+    try {
+        const gamePath = state.settings.gameMode.discovered?.[GAME_ID]?.path;
+        if (!gamePath) {
+            log('info', 'No path save for Hogwarts Legacy, aborting migration');
+            return;
+        }
+        const modsFolder = path.join(gamePath, MODSFOLDER_PATH);
+        await context.api.emitAndAwait('purge-mods-in-path', GAME_ID, '', modsFolder);
+    }
+    catch(err) {
+        log('error', 'Failed to clean up ~mods folder for Hogwarts Legacy', err);
+    }
+
+    for (const mod of defaultMods) {
+        const dispatch = context.api.store?.dispatch
+        dispatch(actions.setModType(GAME_ID, mod.id, 'hogwarts-PAK-modtype'));
+    }
+
+}


### PR DESCRIPTION
Move PAK mods to their own mod type to allow for UE4SS and it's mods to install properly. 