### PR TITLE
Fixed a bug where PAK mods were not deployed properly 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hogwartslegacy",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Vortex Extension for Hogwarts Legacy",
   "author": "lordvoldem0rt",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hogwartslegacy",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Vortex Extension for Hogwarts Legacy",
   "author": "lordvoldem0rt",
   "private": true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import {
 
 // Abstract away a lot of the code for specific features into their own classes.
 import HogwartsMovieInstaller from './installers/hogwarts-installer-movies';
+import HogwartsBluePrintOrLuaInstaller from './installers/hogwarts-installer-bp-lua';
 import HogwartsMovieModType from './modtypes/hogwarts-modtype-movies';
 import HogwartsPAKModType from './modtypes/hogwarts-PAK-modtype';
 import HogwartsMovieMerger from './merges/movies-merge';
@@ -170,6 +171,13 @@ function main(context: types.IExtensionContext) {
     90,
     HogwartsMovieInstaller.test,
     (files) => HogwartsMovieInstaller.install(files, context),
+  );
+  
+  context.registerInstaller(
+    "hogwarts-installer-bp-lua", 
+    90, 
+    HogwartsBluePrintOrLuaInstaller.test, 
+    HogwartsBluePrintOrLuaInstaller.install
   );
 
   context.registerMerge(

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,12 +173,12 @@ function main(context: types.IExtensionContext) {
     (files) => HogwartsMovieInstaller.install(files, context),
   );
   
-  context.registerInstaller(
-    "hogwarts-installer-bp-lua", 
-    90, 
-    HogwartsBluePrintOrLuaInstaller.test, 
-    HogwartsBluePrintOrLuaInstaller.install
-  );
+  // context.registerInstaller(
+  //   "hogwarts-installer-bp-lua", 
+  //   90, 
+  //   HogwartsBluePrintOrLuaInstaller.test, 
+  //   HogwartsBluePrintOrLuaInstaller.install
+  // );
 
   context.registerMerge(
     (game) => HogwartsMovieMerger.test(context, game),

--- a/src/installers/hogwarts-installer-bp-lua.ts
+++ b/src/installers/hogwarts-installer-bp-lua.ts
@@ -1,0 +1,87 @@
+import { types } from 'vortex-api';
+import * as path from 'path';
+import { 
+    GAME_ID, IGNORE_CONFLICTS, PAK_EXTENSIONS  
+} from '../common';
+
+const LUA_EXT = '.lua';
+const LUAInstallPath = path.join('Phoenix','Binaries','Win64','Mods'); // Phoenix\Binaries\Win64\Mods
+const BlueprintInstallPath = path.join('Phoenix','Content','PAKS','LogicMods');
+
+const HogwartsBluePrintOrLuaInstaller = {
+    test,
+    install,
+}
+
+async function test(files: string[], gameId: string): Promise<types.ISupportedResult> {
+    const hasFiles = (list: string[]): boolean => {
+        const validFiles = list.filter(f => 
+            // look for LUA files
+            path.extname(f) === LUA_EXT || 
+            // look for UE4SS qualifiers
+            IGNORE_CONFLICTS.includes(f.toLowerCase())
+        );
+        return !!validFiles.length;
+    }
+
+    return {
+        supported: gameId === GAME_ID && hasFiles(files),
+        requiredFiles: []
+    }
+}
+
+async function install(files: string[]): Promise<types.IInstallResult> {
+    let instructions = [];
+    // Remove directories
+    const filesCleaned = files.filter(f => !!path.extname(f));
+    // Check for Blueprints and map them to the right folder. (PAK/UCAS/UTOC)
+    const pakFiles = filesCleaned.filter(f => PAK_EXTENSIONS.includes(path.extname(f).toLowerCase()));
+    const pakInstructions = pakFiles.map(p => ({
+        type: 'copy',
+        source: p,
+        destination: path.join(BlueprintInstallPath, path.basename(p))
+    }));
+    if (pakInstructions.length) instructions = pakInstructions;
+
+    // Check for Lua scripts and map them to the right folder.
+    const luaFiles = filesCleaned.filter(f => f.toLowerCase().includes('scripts') && path.extname(path.basename(f)) === LUA_EXT);
+    // Get a list of Lua parent folders
+    const luaFolders = luaFiles.map(f => {
+        const splitPath = f.toLowerCase().split(path.sep);
+        const folderIndex: number = splitPath.indexOf('scripts') - 1;
+        if (folderIndex !== -1) {
+            const folderNameLowercased = splitPath[folderIndex];
+            const folderPos = f.toLowerCase().indexOf(folderNameLowercased)
+            return f.substring(folderPos, folderPos+folderNameLowercased.length);
+        }
+    });
+    // Ensure we only have one of each.
+    const luaFoldersUnique = new Set(luaFolders);
+
+    const luaInstallableFiles = [...luaFoldersUnique].reduce((prev, cur) => {
+        const luaModFiles = filesCleaned.filter(f => f.includes(cur)).filter(f => !!path.extname(f));
+        const luaInstructions = luaModFiles.map(f => {
+            const splitPath = f.split(path.sep);
+            const folderIndex = splitPath.indexOf(cur);
+            const endOfPath = splitPath.splice(folderIndex + 1, splitPath.length).join(path.sep);            
+            return {
+                type: 'copy',
+                source: f,
+                destination: path.join(LUAInstallPath, f, endOfPath)
+            }
+        });
+
+        prev = [...luaInstructions, ...prev];
+        return prev;
+    }, []);
+
+    instructions = [...luaInstallableFiles, ...instructions];
+    
+    // Extract the unused files too, just for completeness
+    const unusedInstructions = filesCleaned.filter(f => !instructions.find(i => i.source.toLowerCase() === f.toLowerCase()));
+    if (unusedInstructions.length) instructions = [...instructions, ...unusedInstructions.map(i => ({ type: 'copy', source: i, desination: i }))];
+
+    return { instructions };
+}
+
+export default HogwartsBluePrintOrLuaInstaller;

--- a/src/modtypes/hogwarts-PAK-modtype.ts
+++ b/src/modtypes/hogwarts-PAK-modtype.ts
@@ -28,15 +28,15 @@ async function TestForPakModType(
   if (!pakInstallInstructions.length) return false;
 
   // Exclude criteria. Ignore LUA scripts, or logic mods.
-  const excludeInstructions = copyInstructions.find(
+  const excludeInstructions: types.IInstruction | undefined = copyInstructions.find(
     (i) =>
       i.source?.toLowerCase().endsWith(".lua") ||
       i.source?.toLowerCase().endsWith("ue4sslogicmod.info") ||
       i.source?.toLowerCase().endsWith(".ue4sslogicmod") ||
       i.source?.toLowerCase().endsWith(".logicmod"),
   );
-  // // console.log('Pak mod?', !!excludeInstructions ? false : true);
-  return !excludeInstructions ? false : true;
+  // If excludeInstructions found an excludable file, return false otherwise true. 
+  return excludeInstructions !== undefined ? false : true;
 }
 
 function MergeMods(mod: types.IMod, context: types.IExtensionContext): string {


### PR DESCRIPTION
TestForPakModType was using a single negative `!` as the lint rules did not allow double negatives `!!`. Removed the negation entirely to get the correct result. 