### PR TITLE
Update luaModsUtil.ts

### DIFF
--- a/src/util/luaModsUtil.ts
+++ b/src/util/luaModsUtil.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { fs, log, util, types, selectors } from 'vortex-api';
 import * as actions from '../actions/luaActions';
+import { GAME_ID } from '../common';
 
 interface ILuaMod {
     folderName: string;
@@ -115,7 +116,7 @@ export async function openLuaModsFolder(api: types.IExtensionApi) {
 export async function refreshLuaMods(api: types.IExtensionApi) {
     const state = api.getState();
     const profile: types.IProfile | undefined = selectors.activeProfile(api.getState());
-    if (!profile) return;
+    if (!profile|| profile.gameId !== GAME_ID) return;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const stateLoadOrder = (state.session as any).lualoadorder?.[profile.id] || [];
     const gamePath: string | undefined = state.settings.gameMode.discovered['hogwartslegacy']?.path || undefined;


### PR DESCRIPTION
Stop processing Lua mods if the game isn't installed (or the active profile isn't for Hogwarts Legacy)